### PR TITLE
Updated: SaveSearch API to work with 8.6

### DIFF
--- a/kibana.json
+++ b/kibana.json
@@ -1,5 +1,8 @@
 {
   "id": "excelExport",
+  "owner": {
+	  "name": "excelExport"
+  },
   "version": "1.0.0",
   "kibanaVersion": "kibana",
   "server": false,

--- a/kibana.json
+++ b/kibana.json
@@ -3,7 +3,7 @@
   "owner": {
 	  "name": "excelExport"
   },
-  "version": "1.0.0",
+  "version": "8.6.0",
   "kibanaVersion": "kibana",
   "server": false,
   "ui": true,

--- a/kibana.json
+++ b/kibana.json
@@ -3,7 +3,7 @@
   "owner": {
 	  "name": "excelExport"
   },
-  "version": "8.6.0",
+  "version": "8.6.2",
   "kibanaVersion": "kibana",
   "server": false,
   "ui": true,

--- a/public/panel_action/get_excel_panel_action.ts
+++ b/public/panel_action/get_excel_panel_action.ts
@@ -50,8 +50,8 @@ export class GetExcelPanelAction implements ActionDefinition<ActionContext> {
     const { getSharingData } = await loadSharingDataHelpers();
     return await getSharingData(
       savedSearch.searchSource,
-      savedSearch, // TODO: get unsaved state (using embeddale.searchScope): https://github.com/elastic/kibana/issues/43977
-      this.core.uiSettings
+      savedSearch, // TODO: get unsaved state (using embeddable.searchScope): https://github.com/elastic/kibana/issues/43977
+      embeddable.services
     );
   }
 
@@ -67,13 +67,13 @@ export class GetExcelPanelAction implements ActionDefinition<ActionContext> {
     }
 
     const savedSearch = embeddable.getSavedSearch();
-    const { columns, searchSource } = await this.getSearchSource(savedSearch, embeddable);
+    const { columns, getSearchSource } = await this.getSearchSource(savedSearch, embeddable);
 
     const kibanaTimezone = this.core.uiSettings.get('dateFormat:tz');
     const browserTimezone = kibanaTimezone === 'Browser' ? moment.tz.guess() : kibanaTimezone;
 
     const immediateJobParams: JobParamsDownloadCSV = {
-      searchSource,
+      searchSource: getSearchSource(),
       columns,
       browserTimezone,
       title: savedSearch.title,


### PR DESCRIPTION
The getSharingData API's signature has changed. Updated the calling method to match the signature for v8.6.